### PR TITLE
feat : pallycon-token-sample-python 2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ and figure out which specification to use.
                       .allow_airplay(True)
                       .allow_av_adapter(True)) \
             .ncg(Ncg()
-                 .allow_mobile_abnormal_device(False)
+                 .allow_mobile_abnormal_device(True)
                  .allow_external_display(True)
                  .control_hdcp(0))
    

--- a/pallycon/sample/make_token.py
+++ b/pallycon/sample/make_token.py
@@ -118,7 +118,7 @@ def set_security_policy():
                   .allow_airplay(True)
                   .allow_av_adapter(True)) \
         .ncg(Ncg()
-             .allow_mobile_abnormal_device(False)
+             .allow_mobile_abnormal_device(True)
              .allow_external_display(True)
              .control_hdcp(0))
 

--- a/pallycon/token/pallycon_drm_token_client.py
+++ b/pallycon/token/pallycon_drm_token_client.py
@@ -50,6 +50,10 @@ class PallyConDrmTokenClient:
         self.__drm_type = "FairPlay"
         return self
 
+    def ncg(self):
+        self.__drm_type = "NCG"
+        return self
+
     def site_id(self, site_id):
         self.__site_id = site_id
         return self


### PR DESCRIPTION
- add drm-type setting for `NCG`
- refine default example of using NCG methods
- upload 2.0.2 ver.


resolve : #3